### PR TITLE
 get rid of the ugly eval etc

### DIFF
--- a/samples/async/move.html
+++ b/samples/async/move.html
@@ -10,25 +10,16 @@
     <script language="javascript" type="text/javascript" src="../../lib/uglifyjs-parser.js"></script>
     <script language="javascript" type="text/javascript" src="../../src/jscex.js"></script>
     <script language="javascript" type="text/javascript" src="../../src/jscex.async.js"></script>
-    
-    <script type="text/javascript">
-        var moveAsync = eval(Jscex.compile("async", function(e, startPos, endPos, duration) {
-            for (var t = 0; t < duration; t += 50) {
-                e.style.left = (startPos.x + (endPos.x - startPos.x) * t / duration) + "px";
-                e.style.top = (startPos.y + (endPos.y - startPos.y) * t / duration) + "px";
-                $await(Jscex.Async.sleep(50));
-            }
+    <script language="javascript" type="text/javascript" src="../../src/jscex.runtime.js"></script>
 
-            e.style.left = endPos.x;
-            e.style.top = endPos.y;
-        }));
-        
-        var moveSquareAsync = eval(Jscex.compile("async", function(e) {
+    <script type="text/javascript">
+        var moveAsync = Jscex.load("moveAsync.js");     
+        var moveSquareAsync = Jscex.compileEx("async", function(e) {
             $await(moveAsync(e, {x:100, y:100}, {x:400, y:100}, 1000));
             $await(moveAsync(e, {x:400, y:100}, {x:400, y:400}, 1000));
             $await(moveAsync(e, {x:400, y:400}, {x:100, y:400}, 1000));
             $await(moveAsync(e, {x:100, y:400}, {x:100, y:100}, 1000));
-        }));
+        });
     </script>
 </head>
 <body>

--- a/samples/async/moveAsync.js
+++ b/samples/async/moveAsync.js
@@ -1,0 +1,7 @@
+function moveAsync(e, startPos, endPos, duration) {
+    for (var t = 0; t < duration; t += 50) {
+        e.style.left = (startPos.x + (endPos.x - startPos.x) * t / duration) + "px";
+        e.style.top = (startPos.y + (endPos.y - startPos.y) * t / duration) + "px";
+        $await(Jscex.Async.sleep(50));
+    }
+}

--- a/src/jscex.js
+++ b/src/jscex.js
@@ -1339,7 +1339,9 @@ Jscex = (function () {
     }
 
     function compile(builderName, func) {
-        var funcCode = func.toString();
+        var funcCode = func;
+        if (typeof(funcCode) != "string") //+ func supports the string via riceball
+            funcCode = func.toString();
         var evalCode = "eval(Jscex.compile(" + JSON.stringify(builderName) + ", " + funcCode + "))"
         var evalCodeAst = UglifyJS.parse(evalCode);
 
@@ -1355,9 +1357,36 @@ Jscex = (function () {
         return cg ? cg(newCode) : newCode;
     };
 
+    /*
+     * load and compile aync function script from url via riceball
+     * 
+     * note: currently the jscex compiler supports the compiling one function only. 
+     * so u have to use the load function like this:
+     *    var moveAsync = Jscex.load("moveAsync");
+     *
+     */
+    function load(url, buildname) {
+        if (typeof(buildname) == 'undefined') buildname = 'async';
+        var http = JcxRuntime.createXmlHttp();
+        http.open('GET', url, false);
+        try {
+            http.send(null);
+        } catch(e) {
+            return null;
+        }
+
+        var text = http.responseText;
+        if (text == null) 
+            throw new Error("Unable to load URL: " + url);
+        
+        return jcxGlobal.eval(Jscex.compile(buildname, text));
+    }
+
+
     return {
         "config": {},
         "compile": compile,
+        "load": load,
         "builders": {}
     };
 

--- a/src/jscex.runtime.js
+++ b/src/jscex.runtime.js
@@ -1,0 +1,25 @@
+/*
+ *  Jscex runtime library
+ *
+ *    @author Riceball LEE
+ *
+ */
+jcxGlobal = this;
+
+JcxRuntime = {};
+
+Jscex.compileEx = function(buildname, code) {
+    return jcxGlobal.eval(Jscex.compile(buildname, code));
+}
+
+JcxRuntime.createXmlHttp = function() {
+    var http = null;
+	try{ http = new XMLHttpRequest(); }catch(e){}
+	if (!http) try{ http = new ActiveXObject('Msxml2.XMLHTTP') }catch(e){}
+	if (!http) try{ http = new ActiveXObject('Microsoft.XMLHTTP') }catch(e){}
+	if (!http) try{ http = new ActiveXObject('Msxml2.XMLHTTP.4.0') }catch(e){}
+	if (!http) throw new Error("XmlHTTP not available");
+	return http;
+}
+
+


### PR DESCRIPTION
- get rid of the ugly eval: 
  var aAsyncFunc = Jscex.compileEx();
- load function from url for Jscex
  var aAsyncFunc = Jscex.load('st.js');
- the funccode parameter of the Jscex.compile supports the string type now.
