### PR TITLE
Update src/jscex-jit.js

### DIFF
--- a/src/jscex-jit.js
+++ b/src/jscex-jit.js
@@ -3,9 +3,9 @@
     
     var Jscex;
     
-    var codeGenerator = (typeof eval("(function () {})") == "function") ?
+    var codeGenerator = eval("(function () {})") ?
         function (code) { return code; } :
-        function (code) { return "false || " + code; };
+        function (code) { return "0, " + code; };
         
     // support string type only.
     var stringify = (typeof JSON !== "undefined" && JSON.stringify) ?


### PR DESCRIPTION
We know that due to a parser bug inside Microsoft JScript engine you get undefined value from running eval("(function () {})"),
so we can just use this result value as our input condition.

If the implementation can't even guarantee this buggy behavior, then there left nothing we can assume.

Also, in order to fix this problem, just put "0," before our function expression is enough.
