### PR TITLE
Fix bugs in windc.js cause by UTF8 first char and windows newline

### DIFF
--- a/src/windc.js
+++ b/src/windc.js
@@ -222,6 +222,15 @@ var compile = function (code, binders) {
     }
 }
 
+var fixUTF8andWindowsNewLine = function(code) {
+	if(!code)
+		return code;
+	if (code.charCodeAt(0) === 65279)
+		code = code.substr(1);
+	code = code.replace(/\r/g,"");
+	return code;
+}
+
 if (module.parent) { // command
     exports.compile = compile;
 } else {
@@ -237,6 +246,8 @@ if (module.parent) { // command
 
     var fs = require("fs");
     var code = fs.readFileSync(argv.input, "utf-8");
+	code = fixUTF8andWindowsNewLine(code);
     var newCode = compile(code);
     fs.writeFileSync(argv.output, newCode, "utf-8");
 }
+


### PR DESCRIPTION
1. Narcissus will throw exception when I try to open a file saved as
   `UTF-8`, `UTF-8 without BOM` is fine.
2. Narcissus will throw exception when the codes contains `'\r'`.
